### PR TITLE
Fix 'false' misspelling on aria-expanded attribute in .collapse-header

### DIFF
--- a/src/components/Collapse.vue
+++ b/src/components/Collapse.vue
@@ -58,7 +58,7 @@
 
 <template>
   <div class="collapse collapse-item" :class="{ 'is-active': active }">
-    <div class="collapse-header touchable" role="tab" :aria-expanded="active ? 'true' : 'fase'" @click.prevent="toggle">
+    <div class="collapse-header touchable" role="tab" :aria-expanded="active ? 'true' : 'false'" @click.prevent="toggle">
       <slot name="collapse-header"></slot>
     </div>
     <transition name="fade">


### PR DESCRIPTION
The subject says it all.